### PR TITLE
[issue-18] リスト画面のAPI通信_Data

### DIFF
--- a/kmp/data/src/commonMain/kotlin/jp/co/yumemi/data/mappers/WorkListDataMapper.kt
+++ b/kmp/data/src/commonMain/kotlin/jp/co/yumemi/data/mappers/WorkListDataMapper.kt
@@ -1,0 +1,12 @@
+package jp.co.yumemi.data.mappers
+
+import jp.co.yumemi.data.models.WorkListModel
+import jp.co.yumemi.domain.entities.WorkEntity
+
+internal object WorkListDataMapper {
+    fun toEntity(model: WorkListModel) = WorkEntity(
+        title = model.title,
+        seasonName = model.seasonName,
+        imageUrl = model.imageUrl
+    )
+}

--- a/kmp/data/src/commonMain/kotlin/jp/co/yumemi/data/models/WorkListModel.kt
+++ b/kmp/data/src/commonMain/kotlin/jp/co/yumemi/data/models/WorkListModel.kt
@@ -1,0 +1,10 @@
+package jp.co.yumemi.data.models
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class WorkListModel(
+    val title: String,
+    val seasonName: String,
+    val imageUrl: String?,
+)

--- a/kmp/data/src/commonMain/kotlin/jp/co/yumemi/data/repositories/WorkListDataRepository.kt
+++ b/kmp/data/src/commonMain/kotlin/jp/co/yumemi/data/repositories/WorkListDataRepository.kt
@@ -1,0 +1,17 @@
+package jp.co.yumemi.data.repositories
+
+import jp.co.yumemi.data.mappers.WorkListDataMapper
+import jp.co.yumemi.data.sources.WorkListRemoteDataSource
+import jp.co.yumemi.domain.entities.WorkEntity
+import jp.co.yumemi.domain.repositories.WorkListRepository
+import kotlinx.coroutines.delay
+
+class WorkListDataRepository(
+    private val workListRemoteDataSource: WorkListRemoteDataSource,
+) : WorkListRepository {
+    override suspend fun getWorkList(): List<WorkEntity> {
+        // Mock
+        delay(2_000L)
+        return workListRemoteDataSource.getWorkList().map(WorkListDataMapper::toEntity)
+    }
+}

--- a/kmp/data/src/commonMain/kotlin/jp/co/yumemi/data/sources/WorkListRemoteDataSource.kt
+++ b/kmp/data/src/commonMain/kotlin/jp/co/yumemi/data/sources/WorkListRemoteDataSource.kt
@@ -1,0 +1,7 @@
+package jp.co.yumemi.data.sources
+
+import jp.co.yumemi.data.models.WorkListModel
+
+interface WorkListRemoteDataSource {
+    suspend fun getWorkList(): List<WorkListModel>
+}


### PR DESCRIPTION
## 概要
- リスト画面のAPI通信にあたりData層の実装を行いました。

## チケット番号、Issue番号
- #18 

## レビュー観点

## レビューレベル

<!-- どれかの打ち消し線を外してください。 -->

- ~~Lv0: まったく見ないでAcceptする~~
- Lv1: ぱっとみて違和感がないかチェックしてAcceptする
- ~~Lv2: 仕様レベルまで理解して、仕様通りに動くかある程度検証してAcceptする~~
- ~~Lv3: 実際に環境で動作確認したうえでAcceptする~~

## レビュー優先度

<!-- どれかの打ち消し線を外してください。 -->

- ~~すぐに見てもらいたい（hotfixなど） 🚀~~
- ~~今日中に見てもらいたい 🚗~~
- ~~今日を含めて2営業日以内で見てもらいたい 🚶~~
- 数日以内で見てもらいたい 🐢

## 仕様書へのリンク
https://www.notion.so/yumemi/2-0bb4f929707d4382bd1680a94806d179

## デザインガイドへのリンク
https://www.figma.com/file/KQYTYoiAUwBUgBBzLFx5Zi/Marco-Valentino's-team-library?node-id=2321%3A1110&mode=dev

## API仕様書へのリンク
https://developers.annict.com/docs/rest-api/v1/works#get-v1works

## スクリーンショット



